### PR TITLE
Fix compilation on case-sensitive filesystems (i.e. Linux)

### DIFF
--- a/libraries/JETI_EX_SENSOR/JETI_EX_SENSOR.h
+++ b/libraries/JETI_EX_SENSOR/JETI_EX_SENSOR.h
@@ -14,7 +14,7 @@
 #ifndef JETI_EX_SENSOR_h
 #define JETI_EX_SENSOR_h
 #include <inttypes.h>
-#include <arduino.h>
+#include <Arduino.h>
 
 #define JETI_SENSOR_ID1 0x11 
 #define JETI_SENSOR_ID2 0xA4


### PR DESCRIPTION
Arduino.h has a capital 'A', which matters on Linux.
